### PR TITLE
Pep 3151

### DIFF
--- a/Lib/_oserror.py
+++ b/Lib/_oserror.py
@@ -1,0 +1,104 @@
+"""
+This module defines classes for fine-grained OSError's, which work by
+inspecting the current exception to determine if they should catch it or not.
+Importing this module also adds the new exceptions to the global namespace.
+This module gets imported in Python 2.8's startup process, so it must run
+quickly and successfully.
+"""
+
+# TODO: Implement this module in C.
+
+import errno
+import sys
+import select
+import __builtin__
+
+
+class _OSErrorMeta(type):
+    def __subclasscheck__(cls, other):
+        if cls in getattr(other, '__mro__', ()):
+            return True
+
+        exc = sys.exc_info()[1]
+        if exc is None:
+            return False
+
+        errno = getattr(exc, 'errno', None)
+        if issubclass(other, EnvironmentError) and errno in cls.errno:
+            return True
+        elif issubclass(other, select.error) and exc.args[0] in cls.errno:
+            return True
+        else:
+            return False
+
+
+class _OSError(OSError):
+    __metaclass__ = _OSErrorMeta
+
+
+class BlockingIOError(_OSError):
+    errno = (errno.EAGAIN, errno.EALREADY, errno.EWOULDBLOCK,
+             errno.EINPROGRESS)
+
+
+class ChildProcessError(_OSError):
+    errno = (errno.ECHILD,)
+
+
+class ConnectionError(_OSError):
+    errno = (errno.EPIPE, errno.ESHUTDOWN, errno.ECONNABORTED,
+             errno.ECONNREFUSED, errno.ECONNRESET)
+
+
+class BrokenPipeError(ConnectionError):
+    errno = (errno.EPIPE, errno.ESHUTDOWN)
+
+
+class ConnectionAbortedError(ConnectionError):
+    errno = (errno.ECONNABORTED,)
+
+
+class ConnectionRefusedError(ConnectionError):
+    errno = (errno.ECONNREFUSED,)
+
+
+class ConnectionResetError(ConnectionError):
+    errno = (errno.ECONNRESET,)
+
+
+class FileExistsError(_OSError):
+    errno = (errno.EEXIST,)
+
+
+class FileNotFoundError(_OSError):
+    errno = (errno.ENOENT,)
+
+
+class InterruptedError(_OSError):
+    errno = (errno.EINTR,)
+
+
+class IsADirectoryError(_OSError):
+    errno = (errno.EISDIR,)
+
+
+class NotADirectoryError(_OSError):
+    errno = (errno.ENOTDIR,)
+
+
+class PermissionError(_OSError):
+    errno = (errno.EACCES, errno.EPERM)
+
+
+class ProcessLookupError(_OSError):
+    errno = (errno.ESRCH,)
+
+
+class TimeoutError(_OSError):
+    errno = (errno.ETIMEDOUT,)
+
+__all__ = [x for x in dir() if "Error" in x and not x.startswith("_")]
+globs = globals()
+
+for x in __all__:
+    __builtin__.__dict__[x] = globs[x]

--- a/Lib/_oserror.py
+++ b/Lib/_oserror.py
@@ -10,12 +10,13 @@ quickly and successfully.
 
 import errno
 import sys
-import select
 import __builtin__
 
 
 class _OSErrorMeta(type):
     def __subclasscheck__(cls, other):
+        import select  # Hide import since this module may not be built yet.
+
         if cls in getattr(other, '__mro__', ()):
             return True
 

--- a/Lib/test/test__oserror.py
+++ b/Lib/test/test__oserror.py
@@ -26,6 +26,7 @@ class OSErrorTest(unittest.TestCase):
         self.assertIsSubclass(BlockingIOError, Exception)
         self.assertIsSubclass(BlockingIOError, EnvironmentError)
         self.assertIsSubclass(BlockingIOError, OSError)
+        self.assertIsSubclass(BlockingIOError, BlockingIOError)
         self.assertNotIsSubclass(BlockingIOError, int)
         self.assertNotIsSubclass(BlockingIOError, str)
 
@@ -96,6 +97,13 @@ class OSErrorTest(unittest.TestCase):
             self.fail("FileNotFoundError shouldn't have caught this")
         except:
             pass
+
+    def test_catch_self(self):
+        with self.assertRaises(FileNotFoundError):
+            raise FileNotFoundError()
+
+        with self.assertRaises(OSError):
+            raise FileNotFoundError()
 
     @unittest.skipIf(sys.platform == "win32", "No signal.alarm() Windows")
     def test_select(self):

--- a/Lib/test/test__oserror.py
+++ b/Lib/test/test__oserror.py
@@ -1,0 +1,113 @@
+import unittest
+import select
+import signal
+import sys
+import os
+from test.test_support import run_unittest
+
+
+class OldStyleException:
+    pass
+
+
+class OSErrorTest(unittest.TestCase):
+    def assertIsSubclass(self, cl1, cl2):
+        self.assertTrue(issubclass(cl1, cl2),
+                        "%r is not a subclass of %r" % (cl1, cl2))
+
+    def assertNotIsSubclass(self, cl1, cl2):
+        self.assertFalse(issubclass(cl1, cl2),
+                         "%r is a subclass of %r" % (cl1, cl2))
+
+    def test_subclass(self):
+        # Explicit inheritance
+        self.assertIsSubclass(BlockingIOError, object)
+        self.assertIsSubclass(BlockingIOError, BaseException)
+        self.assertIsSubclass(BlockingIOError, Exception)
+        self.assertIsSubclass(BlockingIOError, EnvironmentError)
+        self.assertIsSubclass(BlockingIOError, OSError)
+        self.assertNotIsSubclass(BlockingIOError, int)
+        self.assertNotIsSubclass(BlockingIOError, str)
+
+        self.assertNotIsSubclass(object, BlockingIOError)
+        self.assertNotIsSubclass(BaseException, BlockingIOError)
+        self.assertNotIsSubclass(Exception, BlockingIOError)
+        self.assertNotIsSubclass(EnvironmentError, BlockingIOError)
+        self.assertNotIsSubclass(OSError, BlockingIOError)
+        self.assertNotIsSubclass(int, BlockingIOError)
+        self.assertNotIsSubclass(str, BlockingIOError)
+
+        # Subclasses of ConnectionError
+        self.assertIsSubclass(ConnectionError, OSError)
+        self.assertIsSubclass(BrokenPipeError, ConnectionError)
+        self.assertIsSubclass(ConnectionAbortedError, ConnectionError)
+        self.assertIsSubclass(ConnectionRefusedError, ConnectionError)
+        self.assertIsSubclass(ConnectionResetError, ConnectionError)
+
+    def test_catch(self):
+        with self.assertRaises(FileNotFoundError):
+            open("this file does not exist")
+
+        try:
+            open("this file does not exist")
+        except FileNotFoundError:
+            pass
+        else:
+            self.fail("FileNotFoundError didn't catch this")
+
+        try:
+            1/0
+        except FileNotFoundError:
+            self.fail("FileNotFoundError shouldn't have caught this")
+        except ZeroDivisionError:
+            pass
+
+    def test_catch_multiple(self):
+        try:
+            open("this file does not exist")
+        except ZeroDivisionError:
+            self.fail("what?!")
+        except ChildProcessError:
+            self.fail("ChildProcessError shouldn't have caught this")
+        except FileNotFoundError:
+            pass
+        else:
+            self.fail("FileNotFoundError didn't catch this")
+
+    def test_catch_nested(self):
+        try:
+            1/0
+        except ZeroDivisionError:
+            try:
+                open("this file does not exist")
+            except ZeroDivisionError:
+                self.fail("what?!")
+            except FileNotFoundError:
+                pass
+            else:
+                self.fail("FileNotFoundError didn't catch this")
+        else:
+            self.fail("what?!")
+
+    def test_old_style(self):
+        try:
+            raise OldStyleException()
+        except FileNotFoundError:
+            self.fail("FileNotFoundError shouldn't have caught this")
+        except:
+            pass
+
+    @unittest.skipIf(sys.platform == "win32", "No signal.alarm() Windows")
+    def test_select(self):
+        signal.signal(signal.SIGALRM, lambda x, y: None)
+        read, _ = os.pipe()
+        signal.alarm(1)
+        with self.assertRaises(InterruptedError):
+            select.select([read], [], [], 5)
+
+
+def test_main():
+    run_unittest(OSErrorTest)
+
+if __name__ == "__main__":
+    test_main()

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -56,6 +56,7 @@ extern grammar _PyParser_Grammar; /* From graminit.c */
 /* Forward */
 static void initmain(void);
 static void initsite(void);
+static void initmod(char *);
 static PyObject *run_mod(mod_ty, const char *, PyObject *, PyObject *,
                           PyCompilerFlags *, PyArena *);
 static PyObject *run_pyc_file(FILE *, const char *, PyObject *, PyObject *,
@@ -279,6 +280,8 @@ Py_InitializeEx(int install_sigs)
 #ifdef WITH_THREAD
     _PyGILState_Init(interp, tstate);
 #endif /* WITH_THREAD */
+
+    initmod("_oserror");  /* Fine-grained OSError's */
 
     if (!Py_NoSiteFlag)
         initsite(); /* Module site */
@@ -722,8 +725,14 @@ initmain(void)
 static void
 initsite(void)
 {
+    initmod("site");
+}
+
+static void
+initmod(char *name)
+{
     PyObject *m;
-    m = PyImport_ImportModule("site");
+    m = PyImport_ImportModule(name);
     if (m == NULL) {
         PyErr_Print();
         Py_Finalize();


### PR DESCRIPTION
Implements part of Pep 3151, (finer grained OSError's that can be used instead of checking errno). Doesn't change the stdlib to start raising them instead of OSError, IOError, mmap.error, select.error, or socket.error.